### PR TITLE
bug fix for searching for characters with cling to shadows

### DIFF
--- a/src/act.stealth.c
+++ b/src/act.stealth.c
@@ -1404,13 +1404,13 @@ ACMD(do_search) {
 				continue;
 			if (!AFF_FLAGGED(targ, AFF_HIDE) || CAN_SEE(ch, targ))
 				continue;
-
-			SET_BIT(AFF_FLAGS(ch), AFF_SENSE_HIDE);
 			
 			if (has_ability(targ, ABIL_CLING_TO_SHADOW)) {
 				gain_ability_exp(targ, ABIL_CLING_TO_SHADOW, 20);
 				continue;
 			}
+
+			SET_BIT(AFF_FLAGS(ch), AFF_SENSE_HIDE);
 
 			if (skill_check(ch, ABIL_SEARCH, DIFF_HARD) && CAN_SEE(ch, targ)) {
 				act("You find $N!", FALSE, ch, 0, targ, TO_CHAR);


### PR DESCRIPTION
Searching for a character that has Cling to Shadows causes AFF_SENSE_HIDE to be set _permanently_ on the character that performs the search. I moved the SET_BIT to after the Cling to Shadows check to fix this.

This only fixes it from happening in the future, and any existing characters that have already done this will still have the sense hide bit set and should probably be edited. 