### PR TITLE
Messaging fixes

### DIFF
--- a/src/act.action.c
+++ b/src/act.action.c
@@ -1669,8 +1669,13 @@ void process_mining(char_data *ch) {
 			cancel_action(ch);
 			break;
 		}
-		if (!room_has_function_and_city_ok(IN_ROOM(ch), FNC_MINE) || get_room_extra_data(IN_ROOM(ch), ROOM_EXTRA_MINE_AMOUNT) <= 0) {
+		if (!room_has_function_and_city_ok(IN_ROOM(ch), FNC_MINE)) {
 			msg_to_char(ch, "You can't mine here.\r\n");
+			cancel_action(ch);
+			break;
+		}
+		if (get_room_extra_data(IN_ROOM(ch), ROOM_EXTRA_MINE_AMOUNT) <= 0) {
+			msg_to_char(ch, "You don't see even a hint of anything worthwhile in this depleted mine.\r\n");
 			cancel_action(ch);
 			break;
 		}

--- a/src/act.empire.c
+++ b/src/act.empire.c
@@ -3323,7 +3323,7 @@ void do_claim_room(char_data *ch, room_data *room) {
 	bool junk;
 	
 	if (!emp) {
-		msg_to_char(ch, "You don't belong to any empre.\r\n");
+		msg_to_char(ch, "You don't belong to any empire.\r\n");
 	}
 	else if (ROOM_OWNER(room) == emp) {
 		msg_to_char(ch, "Your empire already owns this area.\r\n");
@@ -3381,7 +3381,7 @@ void do_claim_vehicle(char_data *ch, vehicle_data *veh) {
 		msg_to_char(ch, "That cannot be claimed.\r\n");
 	}
 	else if (!emp) {
-		msg_to_char(ch, "You don't belong to any empre.\r\n");
+		msg_to_char(ch, "You don't belong to any empire.\r\n");
 	}
 	else if (VEH_OWNER(veh) == emp) {
 		msg_to_char(ch, "Your empire already owns that.\r\n");

--- a/src/act.highsorcery.c
+++ b/src/act.highsorcery.c
@@ -902,7 +902,7 @@ ACMD(do_enervate) {
 		// succeed
 	
 		act("$N starts to glow red as you shout the enervate hex at $M! You feel your own stamina grow as you drain $S.", FALSE, ch, NULL, vict, TO_CHAR);
-		act("$n shouts somthing at you... The world takes on a reddish hue and you feel your stamina drain.", FALSE, ch, NULL, vict, TO_VICT);
+		act("$n shouts something at you... The world takes on a reddish hue and you feel your stamina drain.", FALSE, ch, NULL, vict, TO_VICT);
 		act("$n shouts some kind of hex at $N, who starts to glow red and seems weakened!", FALSE, ch, NULL, vict, TO_NOTVICT);
 	
 		af = create_mod_aff(ATYPE_ENERVATE, 1 MUD_HOURS, APPLY_MOVE_REGEN, -1 * GET_INTELLIGENCE(ch) / 2, ch);
@@ -1389,8 +1389,8 @@ ACMD(do_vigor) {
 		}
 		else {
 			act("You focus your thoughts and say the word 'maktso', and $N suddenly seems refreshed.", FALSE, ch, NULL, vict, TO_CHAR);
-			act("$n closes $s eyes and says the word 'matkso', and you feel a sudden burst of vigor!", FALSE, ch, NULL, vict, TO_VICT);
-			act("$n closes $s eyes and says the word 'matkso', and $N suddenly seems refreshed.", FALSE, ch, NULL, vict, TO_NOTVICT);
+			act("$n closes $s eyes and says the word 'maktso', and you feel a sudden burst of vigor!", FALSE, ch, NULL, vict, TO_VICT);
+			act("$n closes $s eyes and says the word 'maktso', and $N suddenly seems refreshed.", FALSE, ch, NULL, vict, TO_NOTVICT);
 		}
 		
 		// check if vict is in combat

--- a/src/act.item.c
+++ b/src/act.item.c
@@ -1999,7 +1999,7 @@ void add_shipping_queue(char_data *ch, empire_data *emp, int from_island, int to
 	bool done;
 	
 	if (!emp || from_island == NO_ISLAND || to_island == NO_ISLAND || number < 0 || vnum == NOTHING) {
-		msg_to_char(ch, "Unable to set up shipping: invalid inpue.\r\n");
+		msg_to_char(ch, "Unable to set up shipping: invalid input.\r\n");
 		return;
 	}
 	

--- a/src/act.other.c
+++ b/src/act.other.c
@@ -237,7 +237,7 @@ void perform_alternate(char_data *old, char_data *new) {
 	empire_data *old_emp;
 	
 	if (!old || !new || !old->desc || new->desc) {
-		log("SYSERR: Attempting invalid peform_alternate with %s, %s, %s, %s", old ? "ok" : "no old", new ? "ok" : "no new", old->desc ? "ok" : "no old desc", new->desc ? "new desc" : "ok");
+		log("SYSERR: Attempting invalid perform_alternate with %s, %s, %s, %s", old ? "ok" : "no old", new ? "ok" : "no new", old->desc ? "ok" : "no old desc", new->desc ? "new desc" : "ok");
 		return;
 	}
 
@@ -1034,7 +1034,7 @@ void do_alt_import(char_data *ch, char *argument) {
 		alt_import_slash_channels(ch, alt);
 	}
 	else {
-		msg_to_char(ch, "Uknown field '%s'.\r\n%s", arg2, valid_fields);
+		msg_to_char(ch, "Unknown field '%s'.\r\n%s", arg2, valid_fields);
 	}
 
 	// cleanup	
@@ -2305,7 +2305,7 @@ ACMD(do_order) {
 		send_to_char("You obviously suffer from schizophrenia.\r\n", ch);
 	else {
 		if (AFF_FLAGGED(ch, AFF_CHARM)) {
-			send_to_char("Your superior would not aprove of you giving orders.\r\n", ch);
+			send_to_char("Your superior would not approve of you giving orders.\r\n", ch);
 			return;
 		}
 		if (vict) {
@@ -2722,7 +2722,7 @@ ACMD(do_summon) {
 	}
 	
 	if (count > config_get_int("summon_npc_limit")) {
-		msg_to_char(ch, "There are too many npcs here to summon more.\r\n");
+		msg_to_char(ch, "There are too many NPCs here to summon more.\r\n");
 		return;
 	}
 

--- a/src/act.stealth.c
+++ b/src/act.stealth.c
@@ -1092,7 +1092,7 @@ ACMD(do_pickpocket) {
 		send_to_char("Come on now, that's rather stupid!\r\n", ch);
 	}
 	else if (!IS_NPC(vict)) {
-		msg_to_char(ch, "You may only pickpocket npcs.\r\n");
+		msg_to_char(ch, "You may only pickpocket NPCs.\r\n");
 	}
 	else if ((ch_emp = GET_LOYALTY(ch)) && (vict_emp = GET_LOYALTY(vict)) && has_relationship(ch_emp, vict_emp, DIPL_ALLIED | DIPL_NONAGGR)) {
 		msg_to_char(ch, "You can't pickpocket mobs you are allied or have a non-aggression pact with.\r\n");

--- a/src/act.vampire.c
+++ b/src/act.vampire.c
@@ -1200,7 +1200,7 @@ ACMD(do_regenerate) {
 			}
 			case REGEN_MOVE: {
 				msg_to_char(ch, "You focus your blood into your sore muscles.\r\n");
-				act("$n seems envigorated.", TRUE, ch, NULL, NULL, TO_ROOM);
+				act("$n seems invigorated.", TRUE, ch, NULL, NULL, TO_ROOM);
 				GET_MOVE(ch) = MIN(GET_MAX_MOVE(ch), GET_MOVE(ch) + amount);
 				break;
 			}

--- a/src/act.vehicles.c
+++ b/src/act.vehicles.c
@@ -2055,7 +2055,7 @@ ACMD(do_lead) {
 		GET_LEADING_VEHICLE(ch) = NULL;
 	}
 	else if (IS_NPC(ch)) {
-		msg_to_char(ch, "Npcs can't lead anything.\r\n");
+		msg_to_char(ch, "NPCs can't lead anything.\r\n");
 	}
 	else if (GET_SITTING_ON(ch)) {
 		msg_to_char(ch, "You can't lead anything while you're sitting %s something.\r\n", IN_OR_ON(GET_SITTING_ON(ch)));

--- a/src/comm.c
+++ b/src/comm.c
@@ -128,7 +128,7 @@ int tics_passed = 0;					/* for extern checkpointing			*/
 int scheck = 0;							/* for syntax checking mode			*/
 struct timeval null_time;				/* zero-valued time structure		*/
 FILE *logfile = NULL;					/* Where to send the log messages	*/
-bool gain_cond_messsage = FALSE;		/* gain cond send messages			*/
+bool gain_cond_message = FALSE;		/* gain cond send messages			*/
 int dg_act_check;	/* toggle for act_trigger */
 unsigned long pulse = 0;	/* number of pulses since game start */
 static bool reboot_recovery = FALSE;
@@ -956,7 +956,7 @@ void heartbeat(int heart_pulse) {
 
 	// only get a gain condition message on the hour
 	if (HEARTBEAT(SECS_PER_MUD_HOUR)) {
-		gain_cond_messsage = TRUE;
+		gain_cond_message = TRUE;
 	}
 	
 	event_process();
@@ -1142,7 +1142,7 @@ void heartbeat(int heart_pulse) {
 	free_freeable_triggers();
 
 	/* Turn this off */
-	gain_cond_messsage = FALSE;
+	gain_cond_message = FALSE;
 	
 	// prevent accidentally leaving this on
 	pause_affect_total = FALSE;

--- a/src/comm.c
+++ b/src/comm.c
@@ -1888,7 +1888,7 @@ int get_max_players(void) {
 		}
 
 		/* set the current to the maximum */
-		limit.rlim_cur = limit.rlim_max;
+		limit.rlim_cur = MIN(OPEN_MAX, limit.rlim_max);
 		if (setrlimit(RLIMIT_NOFILE, &limit) < 0) {
 			perror("SYSERR: calling setrlimit");
 			exit(1);

--- a/src/config.c
+++ b/src/config.c
@@ -1746,7 +1746,7 @@ void init_config_system(void) {
 	init_config(CONFIG_EMPIRE, "land_outside_city_modifier", CONFTYPE_DOUBLE, "portion of land that can be in the outskirts area of cities");
 	init_config(CONFIG_EMPIRE, "building_population_timer", CONFTYPE_INT, "game hours per citizen move-in");
 	init_config(CONFIG_EMPIRE, "time_to_empire_delete", CONFTYPE_INT, "weeks until an empire is deleted");
-	init_config(CONFIG_EMPIRE, "time_to_empire_emptiness", CONFTYPE_INT, "weeks until npcs don't spawn");
+	init_config(CONFIG_EMPIRE, "time_to_empire_emptiness", CONFTYPE_INT, "weeks until NPCs don't spawn");
 	init_config(CONFIG_EMPIRE, "member_timeout_newbie", CONFTYPE_INT, "days until newbie times out");
 	init_config(CONFIG_EMPIRE, "minutes_per_day_newbie", CONFTYPE_INT, "minutes played per day for noob status");
 	init_config(CONFIG_EMPIRE, "member_timeout_full", CONFTYPE_INT, "days until full member times out");
@@ -1780,7 +1780,7 @@ void init_config_system(void) {
 	init_config(CONFIG_MOBS, "mob_despawn_radius", CONFTYPE_INT, "distance from players to despawn mobs");
 	init_config(CONFIG_MOBS, "npc_follower_limit", CONFTYPE_INT, "more npc followers than this causes aggro");
 	init_config(CONFIG_MOBS, "num_duplicates_in_stable", CONFTYPE_INT, "number of npc duplicates allowed in a stable before some leave");
-	init_config(CONFIG_MOBS, "spawn_limit_per_room", CONFTYPE_INT, "max npcs that will spawn in a map room");
+	init_config(CONFIG_MOBS, "spawn_limit_per_room", CONFTYPE_INT, "max NPCs that will spawn in a map room");
 	init_config(CONFIG_MOBS, "mob_pursuit_timeout", CONFTYPE_INT, "minutes that mob pursuit memory lasts");
 	init_config(CONFIG_MOBS, "mob_pursuit_distance", CONFTYPE_INT, "distance a mob will pursue (as the crow flies)");
 	init_config(CONFIG_MOBS, "use_mob_stacking", CONFTYPE_BOOL, "whether or not mobs show as stacks on look");

--- a/src/generic.c
+++ b/src/generic.c
@@ -1379,7 +1379,7 @@ OLC_MODULE(genedit_build2char) {
 			free(GEN_STRING(gen, GSTR_ACTION_BUILD_TO_CHAR));
 		}
 		GEN_STRING(gen, GSTR_ACTION_BUILD_TO_CHAR) = NULL;
-		msg_to_char(ch, "Build2char messsage removed.\r\n");
+		msg_to_char(ch, "Build2char message removed.\r\n");
 	}
 	else {
 		olc_process_string(ch, argument, "build2char", &GEN_STRING(gen, GSTR_ACTION_BUILD_TO_CHAR));
@@ -1398,7 +1398,7 @@ OLC_MODULE(genedit_build2room) {
 			free(GEN_STRING(gen, GSTR_ACTION_BUILD_TO_ROOM));
 		}
 		GEN_STRING(gen, GSTR_ACTION_BUILD_TO_ROOM) = NULL;
-		msg_to_char(ch, "Build2room messsage removed.\r\n");
+		msg_to_char(ch, "Build2room message removed.\r\n");
 	}
 	else {
 		olc_process_string(ch, argument, "build2room", &GEN_STRING(gen, GSTR_ACTION_BUILD_TO_ROOM));
@@ -1417,7 +1417,7 @@ OLC_MODULE(genedit_craft2char) {
 			free(GEN_STRING(gen, GSTR_ACTION_CRAFT_TO_CHAR));
 		}
 		GEN_STRING(gen, GSTR_ACTION_CRAFT_TO_CHAR) = NULL;
-		msg_to_char(ch, "Craft2char messsage removed.\r\n");
+		msg_to_char(ch, "Craft2char message removed.\r\n");
 	}
 	else {
 		olc_process_string(ch, argument, "craft2char", &GEN_STRING(gen, GSTR_ACTION_CRAFT_TO_CHAR));
@@ -1436,7 +1436,7 @@ OLC_MODULE(genedit_craft2room) {
 			free(GEN_STRING(gen, GSTR_ACTION_CRAFT_TO_ROOM));
 		}
 		GEN_STRING(gen, GSTR_ACTION_CRAFT_TO_ROOM) = NULL;
-		msg_to_char(ch, "Craft2room messsage removed.\r\n");
+		msg_to_char(ch, "Craft2room message removed.\r\n");
 	}
 	else {
 		olc_process_string(ch, argument, "craft2room", &GEN_STRING(gen, GSTR_ACTION_CRAFT_TO_ROOM));
@@ -1455,7 +1455,7 @@ OLC_MODULE(genedit_repair2char) {
 			free(GEN_STRING(gen, GSTR_ACTION_REPAIR_TO_CHAR));
 		}
 		GEN_STRING(gen, GSTR_ACTION_REPAIR_TO_CHAR) = NULL;
-		msg_to_char(ch, "Repair2char messsage removed.\r\n");
+		msg_to_char(ch, "Repair2char message removed.\r\n");
 	}
 	else {
 		olc_process_string(ch, argument, "repair2char", &GEN_STRING(gen, GSTR_ACTION_REPAIR_TO_CHAR));
@@ -1474,7 +1474,7 @@ OLC_MODULE(genedit_repair2room) {
 			free(GEN_STRING(gen, GSTR_ACTION_REPAIR_TO_ROOM));
 		}
 		GEN_STRING(gen, GSTR_ACTION_REPAIR_TO_ROOM) = NULL;
-		msg_to_char(ch, "Repair2room messsage removed.\r\n");
+		msg_to_char(ch, "Repair2room message removed.\r\n");
 	}
 	else {
 		olc_process_string(ch, argument, "repair2room", &GEN_STRING(gen, GSTR_ACTION_REPAIR_TO_ROOM));
@@ -1532,7 +1532,7 @@ OLC_MODULE(genedit_apply2char) {
 			free(GEN_STRING(gen, pos));
 		}
 		GEN_STRING(gen, pos) = NULL;
-		msg_to_char(ch, "Apply-to-char messsage removed.\r\n");
+		msg_to_char(ch, "Apply-to-char message removed.\r\n");
 	}
 	else {
 		olc_process_string(ch, argument, "apply2char", &GEN_STRING(gen, pos));
@@ -1560,7 +1560,7 @@ OLC_MODULE(genedit_apply2room) {
 			free(GEN_STRING(gen, pos));
 		}
 		GEN_STRING(gen, pos) = NULL;
-		msg_to_char(ch, "Apply-to-room messsage removed.\r\n");
+		msg_to_char(ch, "Apply-to-room message removed.\r\n");
 	}
 	else {
 		olc_process_string(ch, argument, "apply2room", &GEN_STRING(gen, pos));
@@ -1783,7 +1783,7 @@ OLC_MODULE(genedit_standardwearoff) {
 		send_config_msg(ch, "ok_string");
 	}
 	else {
-		msg_to_char(ch, "Wear-off messsage changed to: %s\r\n", buf);
+		msg_to_char(ch, "Wear-off message changed to: %s\r\n", buf);
 	}
 }
 
@@ -1812,7 +1812,7 @@ OLC_MODULE(genedit_wearoff) {
 			free(GEN_STRING(gen, pos));
 		}
 		GEN_STRING(gen, pos) = NULL;
-		msg_to_char(ch, "Wear-off messsage removed.\r\n");
+		msg_to_char(ch, "Wear-off message removed.\r\n");
 	}
 	else {
 		olc_process_string(ch, argument, "wearoff", &GEN_STRING(gen, pos));
@@ -1840,7 +1840,7 @@ OLC_MODULE(genedit_wearoff2room) {
 			free(GEN_STRING(gen, pos));
 		}
 		GEN_STRING(gen, pos) = NULL;
-		msg_to_char(ch, "Wear-off-to-room messsage removed.\r\n");
+		msg_to_char(ch, "Wear-off-to-room message removed.\r\n");
 	}
 	else {
 		olc_process_string(ch, argument, "wearoff2room", &GEN_STRING(gen, pos));

--- a/src/limits.c
+++ b/src/limits.c
@@ -1934,7 +1934,7 @@ void update_trading_post(void) {
 * @param int value The amount to gain or lose
 */
 void gain_condition(char_data *ch, int condition, int value) {
-	extern bool gain_cond_messsage;
+	extern bool gain_cond_message;
 	bool intoxicated;
 
 	// no change?
@@ -1964,7 +1964,7 @@ void gain_condition(char_data *ch, int condition, int value) {
 		affect_from_char(ch, ATYPE_WELL_FED, TRUE);
 	}
 
-	if (!gain_cond_messsage) {
+	if (!gain_cond_message) {
 		return;
 	}
 

--- a/src/olc.mobile.c
+++ b/src/olc.mobile.c
@@ -1000,7 +1000,7 @@ OLC_MODULE(medit_allegiance) {
 		msg_to_char(ch, "Set the mob's allegiance to which faction (or 'none')?\r\n");
 	}
 	else if (!str_cmp(argument, "none")) {
-		msg_to_char(ch, "You set its allegience to 'none'.\r\n");
+		msg_to_char(ch, "You set its allegiance to 'none'.\r\n");
 		MOB_FACTION(mob) = NULL;
 	}
 	else if (!(fct = find_faction(argument))) {

--- a/src/olc.object.c
+++ b/src/olc.object.c
@@ -2353,7 +2353,7 @@ OLC_MODULE(oedit_text) {
 	book_data *book;
 	
 	if (!IS_BOOK(obj)) {
-		msg_to_char(ch, "You can only set etxt id on a book.\r\n");
+		msg_to_char(ch, "You can only set text id on a book.\r\n");
 	}
 	else {
 		GET_OBJ_VAL(obj, VAL_BOOK_ID) = olc_process_number(ch, argument, "text id", "text", 0, MAX_INT, GET_OBJ_VAL(obj, VAL_BOOK_ID));

--- a/src/shop.c
+++ b/src/shop.c
@@ -1151,7 +1151,7 @@ OLC_MODULE(shopedit_allegiance) {
 		msg_to_char(ch, "Set the shop's allegiance to which faction (or 'none')?\r\n");
 	}
 	else if (!str_cmp(argument, "none")) {
-		msg_to_char(ch, "You set its allegience to 'none'.\r\n");
+		msg_to_char(ch, "You set its allegiance to 'none'.\r\n");
 		SHOP_ALLEGIANCE(shop) = NULL;
 	}
 	else if (!(fct = find_faction(argument))) {

--- a/src/util/plrconv-20b3-to-ascii.c
+++ b/src/util/plrconv-20b3-to-ascii.c
@@ -930,7 +930,7 @@ int scan_mail_file(void) {
 
 
 /*
- * Retrieves one messsage for a player. The mail is then discarded from
+ * Retrieves one message for a player. The mail is then discarded from
  * the file and the mail index.
  */
 char *read_delete(long recipient, int *from, time_t *timestamp) {


### PR DESCRIPTION
- Split out can't-mine and depleted-mine messages.
- Spelling and typo fixes for messaging.
- Added compatibility fix for OSX (shouldn't cause issues for other platforms)

Special note: Changes of 'matkso' -> 'maktso' are because it's spelled differently in the same function, with 3 instances of 'maktso' and 2 instances of 'matkso'. If the difference is intentional, this can be undone.