### PR TITLE
Compilation fix for systems missing OPEN_MAX

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -1888,6 +1888,9 @@ int get_max_players(void) {
 		}
 
 		/* set the current to the maximum */
+#ifndef OPEN_MAX
+#def OPEN_MAX limit.rlim_max
+#endif
 		limit.rlim_cur = MIN(OPEN_MAX, limit.rlim_max);
 		if (setrlimit(RLIMIT_NOFILE, &limit) < 0) {
 			perror("SYSERR: calling setrlimit");


### PR DESCRIPTION
Per discussion in-game, this compensates for limits.h missing OPEN_MAX on certain systems.