### PR TITLE
Fixed leaking of template list in instance.c

### DIFF
--- a/src/instance.c
+++ b/src/instance.c
@@ -563,6 +563,9 @@ void instantiate_rooms(adv_data *adv, struct instance_data *inst, struct adventu
 			load_wtrigger(room_list[iter]);
 		}
 	}
+	
+	// clean up template_list
+	free(template_list);
 }
 
 


### PR DESCRIPTION
Valgrind report that caused this fix:

```
==8043== 1,180 bytes in 7 blocks are definitely lost in loss record 959 of 1,121
==8043==    at 0x49CF770: calloc (vg_replace_malloc.c:566)
==8043==    by 0x1F46A3: instantiate_rooms (instance.c:476)
==8043==    by 0x1F69EB: build_instance_loc (instance.c:239)
==8043==    by 0x1F6C13: generate_adventure_instances (instance.c:1041)
==8043==    by 0x12DC6B: heartbeat (comm.c:1086)
==8043==    by 0x131E8F: game_loop (comm.c:3846)
==8043==    by 0x132757: init_game (comm.c:3883)
==8043==    by 0x11D43: main (comm.c:4005)
```