### PR TITLE
Vehicle speeds

### DIFF
--- a/lib/text/help/olc.hlp
+++ b/lib/text/help/olc.hlp
@@ -7378,18 +7378,6 @@ Examples:
 
 See also: VEDIT KEYWORDS, VEDIT LONG DESCRIPTION, OLC VEHICLES
 #d
-"WEALTH ITEM" "WEALTH OBJECT"
-
-The WEALTH type represents an object of value. These are not converted to money
-like the COINS type is, but they can be minted into coins by players with a
-mint. Wealth items contribute to an empire's total wealth when they are stored.
-
-This item type has no effect unless the item is stored in normal storage.
-
-Object values:
- 0 - treasure value
- 1 - automint (if 0, workforce won't mint this)
-#d
 "VEDIT SPEED"
 
 Usage:  .speed

--- a/lib/text/help/olc.hlp
+++ b/lib/text/help/olc.hlp
@@ -7384,15 +7384,7 @@ Usage:  .speed
         .speed <number>
 
 The SPEED trait indicates how many speed bonuses are granted to the player 
-while sailing, piloting, or driving the selected vehicle. Acceptable values may
-be listed by using '.speed' on its own.
-
-Values:
- 0 - Very Slow
- 1 - Slow
- 2 - Normal
- 3 - Fast
- 4 - Very Fast
+while sailing, piloting, or driving the selected vehicle.
 
 See also: OLC VEHICLES, SPEED
 #d

--- a/lib/text/help/olc.hlp
+++ b/lib/text/help/olc.hlp
@@ -7386,7 +7386,7 @@ Usage:  .speed
 The SPEED trait indicates how many speed bonuses are granted to the player 
 while sailing, piloting, or driving the selected vehicle.
 
-See also: OLC VEHICLES, SPEED
+See also: OLC VEHICLES
 #d
 "WEALTH ITEM" "WEALTH OBJECT"
 

--- a/lib/text/help/olc.hlp
+++ b/lib/text/help/olc.hlp
@@ -7394,7 +7394,7 @@ Object values:
 
 Usage:  .speed
         .speed <number>
-1234567890123456789012345678901234567890123456789012345678901234567890123456789
+
 The SPEED trait indicates how many speed bonuses are granted to the player 
 while sailing, piloting, or driving the selected vehicle. Acceptable values may
 be listed by using '.speed' on its own.

--- a/lib/text/help/olc.hlp
+++ b/lib/text/help/olc.hlp
@@ -7390,6 +7390,36 @@ Object values:
  0 - treasure value
  1 - automint (if 0, workforce won't mint this)
 #d
+"VEDIT SPEED"
+
+Usage:  .speed
+        .speed <number>
+1234567890123456789012345678901234567890123456789012345678901234567890123456789
+The SPEED trait indicates how many speed bonuses are granted to the player 
+while sailing, piloting, or driving the selected vehicle. Acceptable values may
+be listed by using '.speed' on its own.
+
+Values:
+ 0 - Very Slow
+ 1 - Slow
+ 2 - Normal
+ 3 - Fast
+ 4 - Very Fast
+
+See also: OLC VEHICLES, SPEED
+#d
+"WEALTH ITEM" "WEALTH OBJECT"
+
+The WEALTH type represents an object of value. These are not converted to money
+like the COINS type is, but they can be minted into coins by players with a
+mint. Wealth items contribute to an empire's total wealth when they are stored.
+
+This item type has no effect unless the item is stored in normal storage.
+
+Object values:
+ 0 - treasure value
+ 1 - automint (if 0, workforce won't mint this)
+#d
 "WEAPON ITEM" "WEAPON OBJECT"
 
 The WEAPON item type covers melee/caster weapons.

--- a/src/vehicles.c
+++ b/src/vehicles.c
@@ -2286,11 +2286,11 @@ void do_stat_vehicle(char_data *ch, vehicle_data *veh) {
 		size += snprintf(buf + size, sizeof(buf) - size, "Map Icon: %s\t0 %s\r\n", VEH_ICON(veh), show_color_codes(VEH_ICON(veh)));
 	}
 	
-	size += snprintf(buf + size, sizeof(buf) - size, "Health: [\tc%d\t0/\tc%d\t0], Capacity: [\tc%d\t0/\tc%d\t0], Animals Req: [\tc%d\t0], Move Type: [\ty%s\t0], Speed: [\ty%s\t0]\r\n", (int) VEH_HEALTH(veh), VEH_MAX_HEALTH(veh), VEH_CARRYING_N(veh), VEH_CAPACITY(veh), VEH_ANIMALS_REQUIRED(veh), mob_move_types[VEH_MOVE_TYPE(veh)], vehicle_speed_types[VEH_SPEED_BONUSES(veh)]);
+	size += snprintf(buf + size, sizeof(buf) - size, "Health: [\tc%d\t0/\tc%d\t0], Capacity: [\tc%d\t0/\tc%d\t0], Animals Req: [\tc%d\t0], Move Type: [\ty%s\t0]\r\n", (int) VEH_HEALTH(veh), VEH_MAX_HEALTH(veh), VEH_CARRYING_N(veh), VEH_CAPACITY(veh), VEH_ANIMALS_REQUIRED(veh), mob_move_types[VEH_MOVE_TYPE(veh)]);
 	
 	if (VEH_INTERIOR_ROOM_VNUM(veh) != NOTHING || VEH_MAX_ROOMS(veh) || VEH_DESIGNATE_FLAGS(veh)) {
 		sprintbit(VEH_DESIGNATE_FLAGS(veh), designate_flags, part, TRUE);
-		size += snprintf(buf + size, sizeof(buf) - size, "Interior: [\tc%d\t0 - \ty%s\t0], Rooms: [\tc%d\t0], Designate: \ty%s\t0\r\n", VEH_INTERIOR_ROOM_VNUM(veh), building_proto(VEH_INTERIOR_ROOM_VNUM(veh)) ? GET_BLD_NAME(building_proto(VEH_INTERIOR_ROOM_VNUM(veh))) : "none", VEH_MAX_ROOMS(veh), part);
+		size += snprintf(buf + size, sizeof(buf) - size, "Speed: [\ty%s\t0], Interior: [\tc%d\t0 - \ty%s\t0], Rooms: [\tc%d\t0], Designate: \ty%s\t0\r\n", vehicle_speed_types[VEH_SPEED_BONUSES(veh)], VEH_INTERIOR_ROOM_VNUM(veh), building_proto(VEH_INTERIOR_ROOM_VNUM(veh)) ? GET_BLD_NAME(building_proto(VEH_INTERIOR_ROOM_VNUM(veh))) : "none", VEH_MAX_ROOMS(veh), part);
 	}
 	
 	sprintbit(VEH_FLAGS(veh), vehicle_flags, part, TRUE);


### PR DESCRIPTION
Covers these two requests:

1. still need HELP VEDIT SPEED for the olc option, in lib/text/help/olc.hlp
(alphabetically near other VEDIT helps)
2. The 'stat vehicle' display is slightly too wide with 'Speed' on the health line
(game screens are formatted to 79 characters wide where possible because, believe it
or not, sometimes people still log in from non-scrolling non-wrapping terminals)