### PR TITLE
Update act.empire.c

### DIFF
--- a/src/act.empire.c
+++ b/src/act.empire.c
@@ -4027,11 +4027,6 @@ ACMD(do_esay) {
 		return;
 		}
 
-	if (ACCOUNT_FLAGGED(ch, ACCT_MUTED)) {
-		msg_to_char(ch, "You can't use the empire channel while muted.\r\n");
-		return;
-		}
-
 	skip_spaces(&argument);
 
 	if (!*argument) {


### PR DESCRIPTION
This patch removes the restriction on speaking on public channels while muted. Muting should not remove the ability to speak on the empire channel -- that is too excessive.