### PR TITLE
Add custom pronouns

### DIFF
--- a/lib/text/help/wizhelp.hlp
+++ b/lib/text/help/wizhelp.hlp
@@ -975,6 +975,7 @@ loadroom       PC      MISC         Player always starts here
 name           PC      STRING       Change a player's name
 password       PC      STRING       Change password
 sex            BOTH    MISC         Person's sex
+pronouns       PC      STRING       Change pronouns
 skill          PC      MISC         Changes a skill level
 title          PC      STRING       Player's title
 vampire        PC      BINARY       Makes/unmakes vampires

--- a/src/act.immortal.c
+++ b/src/act.immortal.c
@@ -1967,6 +1967,7 @@ struct set_struct {
 		{ "nodelete", 	LVL_CIMPL, 	PC, 	BINARY },
 		{ "noidleout",	LVL_START_IMM,	PC,		BINARY },
 		{ "sex", 		LVL_START_IMM, 	BOTH, 	MISC },
+		{ "pronouns", 		LVL_START_IMM, 	PC, 	MISC },
 		{ "age",		LVL_START_IMM,	BOTH,	NUMBER },
 		{ "lastname",	LVL_START_IMM,	PC,		MISC },
 		{ "muted",		LVL_START_IMM,	PC, 	BINARY },
@@ -2295,6 +2296,18 @@ int perform_set(char_data *ch, char_data *vict, int mode, char *val_arg) {
 		}
 		change_sex(vict, i);
 		sprintf(output, "%s's sex is now %s.", GET_NAME(vict), genders[(int) GET_REAL_SEX(vict)]);
+	}
+	else if SET_CASE("pronouns") {
+		struct pronoun_data *data = create_pronouns(val_arg);
+		if (!data) {
+			send_to_char("Unknown pronouns\r\n", ch);
+			return (0);
+		}
+		if (GET_PRONOUNS(vict)) {
+			free(GET_PRONOUNS(vict));
+		}
+		GET_PRONOUNS(vict) = data;
+		sprintf(output, "%s's pronouns are now %s.", GET_NAME(vict), val_arg);
 	}
 	else if SET_CASE("age") {
 		if (value < 2 || value > 95) {	/* Arbitrary limits. */

--- a/src/db.player.c
+++ b/src/db.player.c
@@ -877,6 +877,9 @@ void free_char(char_data *ch) {
 		if (GET_TITLE(ch)) {
 			free(GET_TITLE(ch));
 		}
+		if (GET_PRONOUNS(ch)) {
+			free(GET_PRONOUNS(ch));
+		}
 		if (GET_PROMPT(ch)) {
 			free(GET_PROMPT(ch));
 		}
@@ -1953,6 +1956,14 @@ char_data *read_player_from_file(FILE *fl, char *name, bool normal, char_data *c
 				else if (!strn_cmp(line, "Preferences: ", 13)) {
 					PRF_FLAGS(ch) = asciiflag_conv(line + 13);
 				}
+				else if (!strn_cmp(line, "Pronouns: ", 10)) {
+					if (GET_PRONOUNS(ch)) {
+						free(GET_PRONOUNS(ch));
+					}
+					char *pronouns = str_dup(line + 10);
+					GET_PRONOUNS(ch) = create_pronouns(pronouns);
+					free(pronouns);
+				}
 				else if (!strn_cmp(line, "Promo ID: ", 10)) {
 					GET_PROMO_ID(ch) = atoi(line + 10);
 				}
@@ -2740,6 +2751,11 @@ void write_player_primary_data_to_file(FILE *fl, char_data *ch) {
 	}
 	if (PRF_FLAGS(ch)) {
 		fprintf(fl, "Preferences: %s\n", bitv_to_alpha(PRF_FLAGS(ch)));
+	}
+	if (GET_PRONOUNS(ch)) {
+		char *serialized = serialize_pronouns(GET_PRONOUNS(ch));
+		fprintf(fl, "Pronouns: %s\n", serialized);
+		free(serialized);
 	}
 	if (GET_PROMO_ID(ch)) {
 		fprintf(fl, "Promo ID: %d\n", GET_PROMO_ID(ch));
@@ -4505,6 +4521,7 @@ void init_player(char_data *ch) {
 	ch->player.short_descr = NULL;
 	ch->player.long_descr = NULL;
 	ch->player.look_descr = NULL;
+	GET_PRONOUNS(ch) = NULL;
 	GET_PROMPT(ch) = NULL;
 	GET_FIGHT_PROMPT(ch) = NULL;
 	POOFIN(ch) = NULL;

--- a/src/structs.h
+++ b/src/structs.h
@@ -4460,6 +4460,7 @@ struct player_special_data {
 	char *fight_prompt;	// fight prompt
 	char *poofin;	// shown when immortal appears
 	char *poofout;	// shown when immortal disappears
+	struct pronoun_data *pronouns; // optional customization, shown when referring to a player
 	
 	// preferences
 	bitvector_t pref;	// preference flags for PCs.

--- a/src/utils.c
+++ b/src/utils.c
@@ -2608,6 +2608,12 @@ void change_sex(char_data *ch, int sex) {
 		add_companion_mod(cd, CMOD_SEX, sex, NULL);
 		queue_delayed_update(GET_COMPANION(ch), CDU_SAVE);
 	}
+
+	// reset player pronouns
+	if (!IS_NPC(ch) && GET_PRONOUNS(ch)) {
+		free(GET_PRONOUNS(ch));
+		GET_PRONOUNS(ch) = NULL;
+	}
 	
 	// update msdp
 	update_MSDP_gender(ch, UPDATE_SOON);
@@ -6786,6 +6792,96 @@ void update_all_players(char_data *to_message, PLAYER_UPDATE_FUNC(*func)) {
 	}
 }
 
+// Warning: PRONOUN_FORMAT is padded with a NUL byte
+#define PRONOUN_SIZE 16
+#define PRONOUN_FORMAT "%15s"
+struct pronoun_data {
+	char hssh[PRONOUN_SIZE];
+	char hmhr[PRONOUN_SIZE];
+	char hshr[PRONOUN_SIZE];
+};
+
+/**
+* Creates pronouns based on a string
+*
+* @param ch The character
+* @param pronouns A string representing the pronouns
+* @return pronouns Pronouns allocated in the heap
+**/
+struct pronoun_data *create_pronouns(const char *pronouns) {
+	struct pronoun_data *data;
+	CREATE(data, struct pronoun_data, 1);
+	if (!data) {
+		return NULL;
+	}
+	char canary;
+	int rc = sscanf(pronouns,
+		PRONOUN_FORMAT " " PRONOUN_FORMAT " " PRONOUN_FORMAT "%c",
+		data->hssh, data->hmhr, data->hshr, &canary);
+	if (rc != 3) {
+		free(data);
+		return NULL;
+	}
+	return data;
+}
+
+/**
+* Serialize pronouns for a character as a string
+*
+* @param pronouns The pronouns
+* @return string A string suitable to pass to set_pronouns, allocated in the heap
+**/
+char *serialize_pronouns(struct pronoun_data* data) {
+	// Have room for three pronouns, two slashes and a NUL byte
+	size_t buffer_size = (PRONOUN_SIZE * 3) + 3;
+	char *buffer;
+	CREATE(buffer, char, buffer_size);
+	if (!buffer) {
+		return NULL;
+	}
+	snprintf(buffer, buffer_size, "%s %s %s", data->hssh, data->hmhr, data->hshr);
+	return buffer;
+}
+
+// Default pronouns
+struct pronoun_data it_pronouns = { .hssh = "it", .hmhr = "it", .hshr = "its" };
+struct pronoun_data male_pronouns = { .hssh = "he", .hmhr = "him", .hshr = "his" };
+struct pronoun_data female_pronouns = { .hssh = "she", .hmhr = "her", .hshr = "her" };
+struct pronoun_data they_pronouns = { .hssh = "they", .hmhr = "them", .hshr = "their" };
+
+/**
+* This calculates a pronoun for a character, factoring in player ronoun data.
+*
+* @param ch The character
+* @param pronoun PRONOUN_HSHR, PRONOUN_HSSH, or PRONOUN_HMHR
+* @param real Whether to show real un-morphed pronouns
+* @return pronoun The pronoun
+**/
+const char *calc_pronoun(char_data *ch, int pronoun, bool real) {
+	struct pronoun_data *pronouns = NULL;
+	int sex = real ? GET_REAL_SEX(ch) : GET_SEX(ch);
+	if (MOB_FLAGGED((ch), MOB_PLURAL)) {
+		pronouns = &they_pronouns;
+	} else if(!real && CHAR_MORPH_FLAGGED(ch, MORPHF_GENDER_NEUTRAL)) {
+		pronouns = &it_pronouns;
+	} else if (!IS_NPC(ch) && GET_PRONOUNS(ch)) {
+		pronouns = GET_PRONOUNS(ch);
+	} else if(sex == SEX_MALE) {
+		pronouns = &male_pronouns;
+	} else if(sex == SEX_FEMALE) {
+		pronouns = &female_pronouns;
+	} else {
+		pronouns = &it_pronouns;
+	}
+	switch(pronoun) {
+		case PRONOUN_HSSH: return pronouns->hssh;
+		case PRONOUN_HMHR: return pronouns->hmhr;
+		case PRONOUN_HSHR: return pronouns->hshr;
+		default:
+			syslog(SYS_ERROR, LVL_START_IMM, TRUE, "SYSERR: calc_pronoun: Unknown pronoun %i", pronoun);
+			return "PRONOUN_WHAT";
+	}
+}
 
  //////////////////////////////////////////////////////////////////////////////
 //// CONVERTER UTILS /////////////////////////////////////////////////////////

--- a/src/utils.h
+++ b/src/utils.h
@@ -1214,6 +1214,7 @@ int Y_COORD(room_data *room);	// formerly #define Y_COORD(room)  FLAT_Y_COORD(ge
 #define GET_PERSONAL_LASTNAME(ch)  CHECK_PLAYER_SPECIAL((ch), ((ch)->player_specials->personal_lastname))
 #define GET_PLAYER_COINS(ch)  CHECK_PLAYER_SPECIAL((ch), ((ch)->player_specials->coins))
 #define GET_PLEDGE(ch)  CHECK_PLAYER_SPECIAL((ch), ((ch)->player_specials->pledge))
+#define GET_PRONOUNS(ch)  CHECK_PLAYER_SPECIAL((ch), ((ch)->player_specials->pronouns))
 #define GET_PROMO_ID(ch)  CHECK_PLAYER_SPECIAL((ch), ((ch)->player_specials->promo_id))
 #define GET_PROMPT(ch)  CHECK_PLAYER_SPECIAL((ch), ((ch)->player_specials->prompt))
 #define GET_QUESTS(ch)  CHECK_PLAYER_SPECIAL((ch), ((ch)->player_specials->quests))
@@ -1546,13 +1547,21 @@ int Y_COORD(room_data *room);	// formerly #define Y_COORD(room)  FLAT_Y_COORD(ge
  //////////////////////////////////////////////////////////////////////////////
 //// STRING UTILS ////////////////////////////////////////////////////////////
 
-#define HSHR(ch)  (MOB_FLAGGED((ch), MOB_PLURAL) ? "their" : ((GET_SEX(ch) && !CHAR_MORPH_FLAGGED(ch, MORPHF_GENDER_NEUTRAL)) ? (GET_SEX(ch) == SEX_MALE ? "his":"her") :"its"))
-#define HSSH(ch)  (MOB_FLAGGED((ch), MOB_PLURAL) ? "they" : ((GET_SEX(ch) && !CHAR_MORPH_FLAGGED(ch, MORPHF_GENDER_NEUTRAL)) ? (GET_SEX(ch) == SEX_MALE ? "he" :"she") : "it"))
-#define HMHR(ch)  (MOB_FLAGGED((ch), MOB_PLURAL) ? "them" : ((GET_SEX(ch) && !CHAR_MORPH_FLAGGED(ch, MORPHF_GENDER_NEUTRAL)) ? (GET_SEX(ch) == SEX_MALE ? "him":"her") : "it"))
+struct pronoun_data;
+struct pronoun_data *create_pronouns(const char *pronouns);
+char *serialize_pronouns(struct pronoun_data* data);
 
-#define REAL_HSHR(ch)  (MOB_FLAGGED((ch), MOB_PLURAL) ? "their" : (GET_REAL_SEX(ch) ? (GET_REAL_SEX(ch) == SEX_MALE ? "his":"her") :"its"))
-#define REAL_HSSH(ch)  (MOB_FLAGGED((ch), MOB_PLURAL) ? "they" : (GET_REAL_SEX(ch) ? (GET_REAL_SEX(ch) == SEX_MALE ? "he" :"she") : "it"))
-#define REAL_HMHR(ch)  (MOB_FLAGGED((ch), MOB_PLURAL) ? "them" : (GET_REAL_SEX(ch) ? (GET_REAL_SEX(ch) == SEX_MALE ? "him":"her") : "it"))
+#define PRONOUN_HSSH 0
+#define PRONOUN_HMHR 1
+#define PRONOUN_HSHR 2
+const char *calc_pronoun(char_data *ch, int pronoun, bool real);
+
+#define HSSH(ch)  calc_pronoun(ch, PRONOUN_HSSH, false)
+#define HMHR(ch)  calc_pronoun(ch, PRONOUN_HMHR, false)
+#define HSHR(ch)  calc_pronoun(ch, PRONOUN_HSHR, false)
+#define REAL_HSSH(ch)  calc_pronoun(ch, PRONOUN_HSSH, true)
+#define REAL_HMHR(ch)  calc_pronoun(ch, PRONOUN_HMHR, true)
+#define REAL_HSHR(ch)  calc_pronoun(ch, PRONOUN_HSHR, true)
 
 #define AN(string)  (strchr("aeiouAEIOU", *string) ? "an" : "a")
 #define SANA(obj)  (strchr("aeiouyAEIOUY", *(obj)->name) ? "an" : "a")


### PR DESCRIPTION
Sorry for the poor title. This PR implements the following:

- Renames sex to gender in codebase
- Lets users select the neutral gender
- They/them pronouns used for neutral gender on player characters
- Per-user pronouns settable by wizards (for people that want neopronouns like ze/hir/hirs)

This PR doesn't yet implement support for text modification to allow second person addressing of pronouns, ie 'He is' -> 'They are'. That will likely be done by adding an option to the pronoun data struct.