### PR TITLE
Fix uninitialized object buffer in detailed craft listings

### DIFF
--- a/src/olc.craft.c
+++ b/src/olc.craft.c
@@ -255,7 +255,7 @@ char *list_one_craft(craft_data *craft, bool detail) {
 			*abil = '\0';
 		}
 		if (GET_CRAFT_REQUIRES_OBJ(craft) != NOTHING) {
-			safe_snprintf(abil, sizeof(abil), " [%s]", skip_filler(get_obj_name_by_proto(GET_CRAFT_REQUIRES_OBJ(craft))));
+			safe_snprintf(obj, sizeof(obj), " [%s]", skip_filler(get_obj_name_by_proto(GET_CRAFT_REQUIRES_OBJ(craft))));
 		}
 		else {
 			*obj = '\0';


### PR DESCRIPTION
When a craft requires an object, list_one_craft() writes the object description into abil, overwriting the ability description and leaving obj uninitialized. The final formatter then reads obj as a string, causing undefined behavior.
This change writes the object description into obj using sizeof(obj), preserving the ability description and initializing both strings before use.

Bug discovered and patched by GPT-6 Astra Extra High.